### PR TITLE
Fix timer timezone drift

### DIFF
--- a/client/src/components/countdown-timer.tsx
+++ b/client/src/components/countdown-timer.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { Clock } from 'lucide-react';
 
 interface CountdownTimerProps {
-  targetDate?: Date;
+  targetDate?: Date | string;
   onReset?: () => void;
   label?: string;
 }
@@ -11,26 +11,26 @@ interface CountdownTimerProps {
 function getMonthEnd() {
   const now = new Date();
 
-  // End of current month
-  const end = new Date(
-    now.getFullYear(),
-    now.getMonth() + 1,
+  // End of current month in UTC
+  const end = new Date(Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth() + 1,
     0, // last day of current month
     23,
     59,
     59
-  );
+  ));
 
   // If already passed → move to next month
   if (now.getTime() > end.getTime()) {
-    return new Date(
-      now.getFullYear(),
-      now.getMonth() + 2,
+    return new Date(Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth() + 2,
       0,
       23,
       59,
       59
-    );
+    ));
   }
 
   return end;
@@ -45,7 +45,7 @@ export function CountdownTimer({ targetDate, onReset, label }: CountdownTimerPro
   });
 
   useEffect(() => {
-    let target = targetDate || getMonthEnd();
+    let target = targetDate ? new Date(targetDate) : getMonthEnd();
 
     const updateCountdown = () => {
       const now = new Date().getTime();

--- a/client/src/pages/leaderboard.tsx
+++ b/client/src/pages/leaderboard.tsx
@@ -40,12 +40,8 @@ export default function LeaderboardPage() {
     }
   }, [leaderboardData]);
 
-  const handleCountdownReset = () => {
-    refetch();
-  };
-
   const competitionLabel = competitionData?.startDate && competitionData?.endDate
-    ? `${new Date(competitionData.startDate).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })} - ${new Date(competitionData.endDate).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}`
+    ? `${new Date(competitionData.startDate).toLocaleDateString(undefined, { month: 'short', day: 'numeric', timeZone: 'UTC' })} - ${new Date(competitionData.endDate).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' })}`
     : undefined;
 
   const LoadingSkeleton = () => (
@@ -138,8 +134,8 @@ export default function LeaderboardPage() {
           </p>
 
           <CountdownTimer 
-            targetDate={competitionData?.endDate ? new Date(competitionData.endDate) : undefined}
-            onReset={handleCountdownReset}
+            targetDate={competitionData?.endDate}
+            onReset={refetch}
             label={competitionLabel}
           />
         </div>
@@ -347,7 +343,7 @@ export default function LeaderboardPage() {
                 <p>
                   Period: <span className="text-slate-300">
                     {competitionData?.startDate && competitionData?.endDate
-                      ? `${new Date(competitionData.startDate).toLocaleDateString()} - ${new Date(competitionData.endDate).toLocaleDateString()}`
+                      ? `${new Date(competitionData.startDate).toLocaleDateString(undefined, { timeZone: 'UTC' })} - ${new Date(competitionData.endDate).toLocaleDateString(undefined, { timeZone: 'UTC' })}`
                       : 'May 01 - May 31'
                     }
                   </span>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -329,10 +329,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
       // Create a new monthly competition starting today
       const now = new Date();
       // End of current month
-      let end = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+      let end = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 0, 23, 59, 59));
       // Ensure we have at least a few days, otherwise go to next month
       if (end.getTime() - now.getTime() < 3 * 24 * 60 * 60 * 1000) {
-        end = new Date(now.getFullYear(), now.getMonth() + 2, 0);
+        end = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 2, 0, 23, 59, 59));
       }
 
       const newCompetition = await storage.createCompetition({

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -36,8 +36,8 @@ export class MemStorage implements IStorage {
 
   private initializeCurrentCompetition() {
     // May 2026 competition
-    const startDate = new Date(2026, 4, 1);
-    const endDate = new Date(2026, 4, 31, 23, 59, 59);
+    const startDate = new Date(Date.UTC(2026, 4, 1));
+    const endDate = new Date(Date.UTC(2026, 4, 31, 23, 59, 59));
     
     const competition: Competition = {
       id: this.currentCompetitionId++,


### PR DESCRIPTION
Fix timezone inconsistencies causing the competition countdown timer and dates to display incorrectly

- Change `LeaderboardPage`'s `competitionLabel` formatting to universally apply `{ timeZone: 'UTC' }` to prevent users in negative-offset timezones from seeing the competition dates prematurely shifting backward (e.g., to "Apr 30").
- Eliminate dependency thrashing in `CountdownTimer` by passing the string `targetDate` and passing the stable `refetch` function reference.
- Initialize server `currentCompetition` defaults inside `storage.ts` and `routes.ts` strictly using `Date.UTC()` to avoid local server timezone boundaries leaking into UTC properties.
- Fix the client's localized fallback `getMonthEnd()` helper to resolve based on `Date.UTC`.

---
*PR created automatically by Jules for task [8738473616400052564](https://jules.google.com/task/8738473616400052564) started by @ProCoderShekhar*