### PR TITLE
Fix build failure due to syntax error in leaderboard.tsx

### DIFF
--- a/client/src/pages/leaderboard.tsx
+++ b/client/src/pages/leaderboard.tsx
@@ -46,19 +46,19 @@ export default function LeaderboardPage() {
 
 const now = new Date();
 
-const competitionLabel = `${now.toLocaleDateString(undefined, {
-  month: 'short'
-})} 1 - ${new Date(
-  now.getFullYear(),
-  now.getMonth() + 1,
-  0
-).toLocaleDateString(undefined, {
-  month: 'short',
-  day: 'numeric',
-  year: 'numeric'
-})}`;
+const competitionLabel = competitionData?.startDate && competitionData?.endDate
     ? `${new Date(competitionData.startDate).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })} - ${new Date(competitionData.endDate).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}`
-    : undefined;
+    : `${now.toLocaleDateString(undefined, {
+        month: 'short'
+      })} 1 - ${new Date(
+        now.getFullYear(),
+        now.getMonth() + 1,
+        0
+      ).toLocaleDateString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric'
+      })}`;
 
   const LoadingSkeleton = () => (
     <div className="space-y-6">


### PR DESCRIPTION
Fixing the syntax error around `competitionLabel` where a ternary operator followed a semicolon from string interpolation. The new code correctly uses `competitionData?.startDate && competitionData?.endDate` as the condition for displaying the start/end dates instead of throwing a build error.

---
*PR created automatically by Jules for task [13343019465619520960](https://jules.google.com/task/13343019465619520960) started by @ProCoderShekhar*