### PR TITLE
Update leaderboard competition dates to June 2026

### DIFF
--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -18,8 +18,8 @@ export function formatNumber(num: number): string {
 }
 
 export function getNextResetDate(): Date {
-  // Fixed competition end date for May 2026
-  return new Date(2026, 4, 31, 23, 59, 59); // May 31, 2026 11:59:59 PM
+  // Fixed competition end date for June 2026
+  return new Date(Date.UTC(2026, 5, 30, 23, 59, 59)); // June 30, 2026 11:59:59 PM UTC
 }
 
 export function getPrizeForRank(rank: number): number {

--- a/client/src/pages/leaderboard.tsx
+++ b/client/src/pages/leaderboard.tsx
@@ -47,9 +47,10 @@ export default function LeaderboardPage() {
 const now = new Date();
 
 const competitionLabel = competitionData?.startDate && competitionData?.endDate
-    ? `${new Date(competitionData.startDate).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })} - ${new Date(competitionData.endDate).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}`
+    ? `${new Date(competitionData.startDate).toLocaleDateString(undefined, { month: 'short', day: 'numeric', timeZone: 'UTC' })} - ${new Date(competitionData.endDate).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' })}`
     : `${now.toLocaleDateString(undefined, {
-        month: 'short'
+        month: 'short',
+        timeZone: 'UTC'
       })} 1 - ${new Date(
         now.getFullYear(),
         now.getMonth() + 1,
@@ -57,7 +58,8 @@ const competitionLabel = competitionData?.startDate && competitionData?.endDate
       ).toLocaleDateString(undefined, {
         month: 'short',
         day: 'numeric',
-        year: 'numeric'
+        year: 'numeric',
+        timeZone: 'UTC'
       })}`;
 
   const LoadingSkeleton = () => (
@@ -358,8 +360,8 @@ const competitionLabel = competitionData?.startDate && competitionData?.endDate
                 <p>
                   Period: <span className="text-slate-300">
                     {competitionData?.startDate && competitionData?.endDate
-                      ? `${new Date(competitionData.startDate).toLocaleDateString()} - ${new Date(competitionData.endDate).toLocaleDateString()}`
-                      : 'May 01 - May 31'
+                      ? `${new Date(competitionData.startDate).toLocaleDateString(undefined, { timeZone: 'UTC' })} - ${new Date(competitionData.endDate).toLocaleDateString(undefined, { timeZone: 'UTC' })}`
+                      : 'Jun 01 - Jun 30'
                     }
                   </span>
                 </p>

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -35,9 +35,9 @@ export class MemStorage implements IStorage {
   }
 
   private initializeCurrentCompetition() {
-    // May 2026 competition
-    const startDate = new Date(2026, 4, 1);
-    const endDate = new Date(2026, 4, 31, 23, 59, 59);
+    // June 2026 competition
+    const startDate = new Date(Date.UTC(2026, 5, 1));
+    const endDate = new Date(Date.UTC(2026, 5, 30, 23, 59, 59));
     
     const competition: Competition = {
       id: this.currentCompetitionId++,


### PR DESCRIPTION
The leaderboard competition has been updated to run for the month of June 2026. This includes updates to the backend storage initialization, the frontend reset timer utility, and the leaderboard UI display. All dates are now handled using UTC to ensure consistency across different timezones. Stale cache data was also cleared to ensure a fresh start for the new competition period.

---
*PR created automatically by Jules for task [7746076098556183986](https://jules.google.com/task/7746076098556183986) started by @ProCoderShekhar*