### PR TITLE
Add Previous Leaderboard and View All Players functionality

### DIFF
--- a/client/src/pages/leaderboard.tsx
+++ b/client/src/pages/leaderboard.tsx
@@ -16,6 +16,8 @@ const STAKE_US_URL = "https://stake.us/?offer=bul&c=d245abdd90";
 
 export default function LeaderboardPage() {
   const [lastUpdated, setLastUpdated] = useState<string>('');
+  const [period, setPeriod] = useState<'current' | 'previous'>('current');
+  const [showAll, setShowAll] = useState(false);
 
   const { 
     data: leaderboardData, 
@@ -24,7 +26,7 @@ export default function LeaderboardPage() {
     refetch 
   } = useQuery<LeaderboardData>({
     queryKey: [
-      `/api/leaderboard?source=all`
+      `/api/leaderboard?source=all&period=${period}${showAll ? '&limit=all' : ''}`
     ],
     refetchInterval: 30000,
   });
@@ -193,12 +195,40 @@ const competitionLabel = competitionData?.startDate && competitionData?.endDate
       <section className="py-6 sm:py-8">
         <div className="max-w-7xl mx-auto px-4 sm:px-6">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 sm:gap-4 mb-6 sm:mb-8">
-            <h2 className="text-xl sm:text-2xl lg:text-3xl font-bold text-slate-50">Current Rankings</h2>
-          <div className="flex items-center gap-3">
-            {/* Live indicator */}
+            <h2 className="text-xl sm:text-2xl lg:text-3xl font-bold text-slate-50">
+              {period === 'current' ? 'Current Rankings' : 'Previous Rankings'}
+            </h2>
+            <div className="flex flex-wrap items-center gap-4">
+              {/* Tab Switcher */}
+              <div className="flex p-1 bg-slate-900 rounded-xl border border-slate-800">
+                <button
+                  onClick={() => { setPeriod('current'); setShowAll(false); }}
+                  className={`px-4 py-2 text-xs sm:text-sm font-semibold rounded-lg transition-all ${
+                    period === 'current'
+                      ? 'bg-blue-600 text-white shadow-lg'
+                      : 'text-slate-400 hover:text-slate-200'
+                  }`}
+                >
+                  Current
+                </button>
+                <button
+                  onClick={() => { setPeriod('previous'); setShowAll(false); }}
+                  className={`px-4 py-2 text-xs sm:text-sm font-semibold rounded-lg transition-all ${
+                    period === 'previous'
+                      ? 'bg-blue-600 text-white shadow-lg'
+                      : 'text-slate-400 hover:text-slate-200'
+                  }`}
+                >
+                  Previous
+                </button>
+              </div>
+
+              {/* Live indicator */}
               <div className="flex items-center space-x-2">
-                <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse"></div>
-              <span className="text-xs sm:text-sm text-slate-400">Live Data • Merged</span>
+                <div className={`w-2 h-2 rounded-full ${period === 'current' ? 'bg-green-500 animate-pulse' : 'bg-slate-500'}`}></div>
+                <span className="text-xs sm:text-sm text-slate-400">
+                  {period === 'current' ? 'Live Data • Merged' : 'Final Results • Merged'}
+                </span>
               </div>
             </div>
           </div>
@@ -216,16 +246,19 @@ const competitionLabel = competitionData?.startDate && competitionData?.endDate
               {/* Full Rankings */}
               <div className="space-y-4">
                 {/* Existing players from API */}
-                {leaderboardData.players.slice(3).map((player) => (
-                  <LeaderboardCard 
-                    key={player.rank} 
-                    player={player}
-                    isTopThree={false}
-                  />
-                ))}
+                {(showAll ? leaderboardData.players : leaderboardData.players.slice(0, 10)).map((player, index) => {
+                  if (!showAll && index < 3) return null;
+                  return (
+                    <LeaderboardCard
+                      key={`${player.username}-${player.rank}`}
+                      player={player}
+                      isTopThree={!showAll && index < 3}
+                    />
+                  );
+                })}
                 
-                {/* Placeholder entries to fill up to 10 total */}
-                {Array.from({ length: Math.max(0, 10 - leaderboardData.players.length) }, (_, index) => {
+                {/* Placeholder entries to fill up to 10 total if not showing all */}
+                {!showAll && Array.from({ length: Math.max(0, 10 - leaderboardData.players.length) }, (_, index) => {
                   const rank = leaderboardData.players.length + index + 1;
                   const placeholderPlayer = {
                     username: "---",
@@ -242,6 +275,19 @@ const competitionLabel = competitionData?.startDate && competitionData?.endDate
                   );
                 })}
               </div>
+
+              {/* View All Button */}
+              {!showAll && leaderboardData.totalPlayers > 10 && (
+                <div className="mt-8 text-center">
+                  <button
+                    onClick={() => setShowAll(true)}
+                    className="px-8 py-3 bg-slate-900 hover:bg-slate-800 text-slate-200 font-semibold rounded-xl border border-slate-800 transition-all flex items-center space-x-2 mx-auto"
+                  >
+                    <span>Show Full Leaderboard</span>
+                    <Users className="w-4 h-4" />
+                  </button>
+                </div>
+              )}
 
               {/* Empty State */}
               {leaderboardData.players.length === 0 && (

--- a/server/data/leaderboard.json
+++ b/server/data/leaderboard.json
@@ -1,0 +1,535 @@
+{
+  "all": {
+    "rawPlayers": [
+      {
+        "username": "Monkeynuts7",
+        "totalWager": 58870.57
+      },
+      {
+        "username": "Sheckmate50",
+        "totalWager": 27747.8
+      },
+      {
+        "username": "Deadhulk6999",
+        "totalWager": 13759.26
+      },
+      {
+        "username": "quietriver86",
+        "totalWager": 5400.61
+      },
+      {
+        "username": "ImZooming",
+        "totalWager": 5245.59
+      },
+      {
+        "username": "Webweaver",
+        "totalWager": 2525.98
+      },
+      {
+        "username": "BlitzPker",
+        "totalWager": 1650.76
+      },
+      {
+        "username": "Niteslayer744",
+        "totalWager": 1317.28
+      },
+      {
+        "username": "Glock70",
+        "totalWager": 1066.22
+      },
+      {
+        "username": "ArcaneCar",
+        "totalWager": 664.9
+      },
+      {
+        "username": "Runelites",
+        "totalWager": 606.23
+      },
+      {
+        "username": "SuperCombatPot",
+        "totalWager": 514
+      },
+      {
+        "username": "DarkBowRun",
+        "totalWager": 486.14
+      },
+      {
+        "username": "Paulwalkerrrr",
+        "totalWager": 374.43
+      },
+      {
+        "username": "Dopebully",
+        "totalWager": 193.3
+      },
+      {
+        "username": "Julia20047",
+        "totalWager": 161.82
+      },
+      {
+        "username": "RakeBackDog",
+        "totalWager": 126.53
+      },
+      {
+        "username": "betrust88",
+        "totalWager": 102.1
+      },
+      {
+        "username": "NoShotHit",
+        "totalWager": 99.22
+      },
+      {
+        "username": "QuadroAlass",
+        "totalWager": 7.39
+      },
+      {
+        "username": "Avernics",
+        "totalWager": 6.43
+      },
+      {
+        "username": "togo12",
+        "totalWager": 16680.57
+      },
+      {
+        "username": "Crappincaptain",
+        "totalWager": 2355.06
+      },
+      {
+        "username": "oopoobieoo",
+        "totalWager": 2140.85
+      },
+      {
+        "username": "aerialpenguin",
+        "totalWager": 1458.4
+      },
+      {
+        "username": "Str8BTW",
+        "totalWager": 314.24
+      },
+      {
+        "username": "shubbyartist",
+        "totalWager": 59.62
+      },
+      {
+        "username": "Nik2Tik",
+        "totalWager": 45.37
+      },
+      {
+        "username": "fuizonwave",
+        "totalWager": 5
+      },
+      {
+        "username": "Mcmurder20",
+        "totalWager": 1.15
+      },
+      {
+        "username": "DoobieTime",
+        "totalWager": 1.1
+      },
+      {
+        "username": "Marc1997386",
+        "totalWager": 0.2
+      }
+    ],
+    "prevPlayers": [
+      {
+        "username": "Monkeynuts7",
+        "totalWager": 58870.57
+      },
+      {
+        "username": "Sheckmate50",
+        "totalWager": 27747.8
+      },
+      {
+        "username": "Deadhulk6999",
+        "totalWager": 13759.26
+      },
+      {
+        "username": "quietriver86",
+        "totalWager": 5400.61
+      },
+      {
+        "username": "ImZooming",
+        "totalWager": 5245.59
+      },
+      {
+        "username": "Webweaver",
+        "totalWager": 2525.98
+      },
+      {
+        "username": "BlitzPker",
+        "totalWager": 1650.76
+      },
+      {
+        "username": "Niteslayer744",
+        "totalWager": 1317.28
+      },
+      {
+        "username": "Glock70",
+        "totalWager": 1066.22
+      },
+      {
+        "username": "ArcaneCar",
+        "totalWager": 664.9
+      },
+      {
+        "username": "Runelites",
+        "totalWager": 606.23
+      },
+      {
+        "username": "SuperCombatPot",
+        "totalWager": 514
+      },
+      {
+        "username": "DarkBowRun",
+        "totalWager": 486.14
+      },
+      {
+        "username": "Paulwalkerrrr",
+        "totalWager": 374.43
+      },
+      {
+        "username": "Dopebully",
+        "totalWager": 193.3
+      },
+      {
+        "username": "Julia20047",
+        "totalWager": 161.82
+      },
+      {
+        "username": "RakeBackDog",
+        "totalWager": 126.53
+      },
+      {
+        "username": "betrust88",
+        "totalWager": 102.1
+      },
+      {
+        "username": "NoShotHit",
+        "totalWager": 99.22
+      },
+      {
+        "username": "QuadroAlass",
+        "totalWager": 7.39
+      },
+      {
+        "username": "Avernics",
+        "totalWager": 6.43
+      },
+      {
+        "username": "togo12",
+        "totalWager": 16680.57
+      },
+      {
+        "username": "Crappincaptain",
+        "totalWager": 2355.06
+      },
+      {
+        "username": "oopoobieoo",
+        "totalWager": 2140.85
+      },
+      {
+        "username": "aerialpenguin",
+        "totalWager": 1458.4
+      },
+      {
+        "username": "Str8BTW",
+        "totalWager": 314.24
+      },
+      {
+        "username": "shubbyartist",
+        "totalWager": 59.62
+      },
+      {
+        "username": "Nik2Tik",
+        "totalWager": 45.37
+      },
+      {
+        "username": "fuizonwave",
+        "totalWager": 5
+      },
+      {
+        "username": "Mcmurder20",
+        "totalWager": 1.15
+      },
+      {
+        "username": "DoobieTime",
+        "totalWager": 1.1
+      },
+      {
+        "username": "Marc1997386",
+        "totalWager": 0.2
+      }
+    ],
+    "lastUpdated": 1782236873406
+  },
+  "com": {
+    "rawPlayers": [
+      {
+        "username": "Monkeynuts7",
+        "totalWager": 58870.57
+      },
+      {
+        "username": "Sheckmate50",
+        "totalWager": 27747.8
+      },
+      {
+        "username": "Deadhulk6999",
+        "totalWager": 13759.26
+      },
+      {
+        "username": "quietriver86",
+        "totalWager": 5400.61
+      },
+      {
+        "username": "ImZooming",
+        "totalWager": 5245.59
+      },
+      {
+        "username": "Webweaver",
+        "totalWager": 2525.98
+      },
+      {
+        "username": "BlitzPker",
+        "totalWager": 1650.76
+      },
+      {
+        "username": "Niteslayer744",
+        "totalWager": 1317.28
+      },
+      {
+        "username": "Glock70",
+        "totalWager": 1066.22
+      },
+      {
+        "username": "ArcaneCar",
+        "totalWager": 664.9
+      },
+      {
+        "username": "Runelites",
+        "totalWager": 606.23
+      },
+      {
+        "username": "SuperCombatPot",
+        "totalWager": 514
+      },
+      {
+        "username": "DarkBowRun",
+        "totalWager": 486.14
+      },
+      {
+        "username": "Paulwalkerrrr",
+        "totalWager": 374.43
+      },
+      {
+        "username": "Dopebully",
+        "totalWager": 193.3
+      },
+      {
+        "username": "Julia20047",
+        "totalWager": 161.82
+      },
+      {
+        "username": "RakeBackDog",
+        "totalWager": 126.53
+      },
+      {
+        "username": "betrust88",
+        "totalWager": 102.1
+      },
+      {
+        "username": "NoShotHit",
+        "totalWager": 99.22
+      },
+      {
+        "username": "QuadroAlass",
+        "totalWager": 7.39
+      },
+      {
+        "username": "Avernics",
+        "totalWager": 6.43
+      }
+    ],
+    "prevPlayers": [
+      {
+        "username": "Monkeynuts7",
+        "totalWager": 58870.57
+      },
+      {
+        "username": "Sheckmate50",
+        "totalWager": 27747.8
+      },
+      {
+        "username": "Deadhulk6999",
+        "totalWager": 13759.26
+      },
+      {
+        "username": "quietriver86",
+        "totalWager": 5400.61
+      },
+      {
+        "username": "ImZooming",
+        "totalWager": 5245.59
+      },
+      {
+        "username": "Webweaver",
+        "totalWager": 2525.98
+      },
+      {
+        "username": "BlitzPker",
+        "totalWager": 1650.76
+      },
+      {
+        "username": "Niteslayer744",
+        "totalWager": 1317.28
+      },
+      {
+        "username": "Glock70",
+        "totalWager": 1066.22
+      },
+      {
+        "username": "ArcaneCar",
+        "totalWager": 664.9
+      },
+      {
+        "username": "Runelites",
+        "totalWager": 606.23
+      },
+      {
+        "username": "SuperCombatPot",
+        "totalWager": 514
+      },
+      {
+        "username": "DarkBowRun",
+        "totalWager": 486.14
+      },
+      {
+        "username": "Paulwalkerrrr",
+        "totalWager": 374.43
+      },
+      {
+        "username": "Dopebully",
+        "totalWager": 193.3
+      },
+      {
+        "username": "Julia20047",
+        "totalWager": 161.82
+      },
+      {
+        "username": "RakeBackDog",
+        "totalWager": 126.53
+      },
+      {
+        "username": "betrust88",
+        "totalWager": 102.1
+      },
+      {
+        "username": "NoShotHit",
+        "totalWager": 99.22
+      },
+      {
+        "username": "QuadroAlass",
+        "totalWager": 7.39
+      },
+      {
+        "username": "Avernics",
+        "totalWager": 6.43
+      }
+    ],
+    "lastUpdated": 1782236873405
+  },
+  "us": {
+    "rawPlayers": [
+      {
+        "username": "togo12",
+        "totalWager": 16680.57
+      },
+      {
+        "username": "Crappincaptain",
+        "totalWager": 2355.06
+      },
+      {
+        "username": "oopoobieoo",
+        "totalWager": 2140.85
+      },
+      {
+        "username": "aerialpenguin",
+        "totalWager": 1458.4
+      },
+      {
+        "username": "Str8BTW",
+        "totalWager": 314.24
+      },
+      {
+        "username": "shubbyartist",
+        "totalWager": 59.62
+      },
+      {
+        "username": "Nik2Tik",
+        "totalWager": 45.37
+      },
+      {
+        "username": "fuizonwave",
+        "totalWager": 5
+      },
+      {
+        "username": "Mcmurder20",
+        "totalWager": 1.15
+      },
+      {
+        "username": "DoobieTime",
+        "totalWager": 1.1
+      },
+      {
+        "username": "Marc1997386",
+        "totalWager": 0.2
+      }
+    ],
+    "prevPlayers": [
+      {
+        "username": "togo12",
+        "totalWager": 16680.57
+      },
+      {
+        "username": "Crappincaptain",
+        "totalWager": 2355.06
+      },
+      {
+        "username": "oopoobieoo",
+        "totalWager": 2140.85
+      },
+      {
+        "username": "aerialpenguin",
+        "totalWager": 1458.4
+      },
+      {
+        "username": "Str8BTW",
+        "totalWager": 314.24
+      },
+      {
+        "username": "shubbyartist",
+        "totalWager": 59.62
+      },
+      {
+        "username": "Nik2Tik",
+        "totalWager": 45.37
+      },
+      {
+        "username": "fuizonwave",
+        "totalWager": 5
+      },
+      {
+        "username": "Mcmurder20",
+        "totalWager": 1.15
+      },
+      {
+        "username": "DoobieTime",
+        "totalWager": 1.1
+      },
+      {
+        "username": "Marc1997386",
+        "totalWager": 0.2
+      }
+    ],
+    "lastUpdated": 1782236873383
+  }
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -16,12 +16,13 @@ type SourceKey = "all" | "com" | "us";
 const HOURLY_MS = 60 * 60 * 1000;
 interface SourceSnapshot {
   rawPlayers: Array<{ username: string; totalWager: number }>;
+  prevPlayers: Array<{ username: string; totalWager: number }>;
   lastUpdated: number;
 }
 const hourlyCache: Record<SourceKey, SourceSnapshot> = {
-  all: { rawPlayers: [], lastUpdated: 0 },
-  com: { rawPlayers: [], lastUpdated: 0 },
-  us: { rawPlayers: [], lastUpdated: 0 },
+  all: { rawPlayers: [], prevPlayers: [], lastUpdated: 0 },
+  com: { rawPlayers: [], prevPlayers: [], lastUpdated: 0 },
+  us: { rawPlayers: [], prevPlayers: [], lastUpdated: 0 },
 };
 
 // Snapshot file on disk
@@ -44,7 +45,12 @@ function loadSnapshotFromDisk() {
       const raw = fs.readFileSync(snapshotFile, "utf8");
       const parsed = JSON.parse(raw) as Record<SourceKey, SourceSnapshot>;
       ( ["all","com","us"] as const ).forEach((k) => {
-        if (parsed?.[k]?.rawPlayers) hourlyCache[k] = parsed[k];
+        if (parsed?.[k]?.rawPlayers) {
+          hourlyCache[k] = {
+            ...parsed[k],
+            prevPlayers: parsed[k].prevPlayers || []
+          };
+        }
       });
       console.log("Loaded leaderboard snapshot from disk");
     }
@@ -87,9 +93,12 @@ function maskUsername(username: string): string {
   return trimmed.substring(0, 3) + "*".repeat(Math.max(3, trimmed.length - 3));
 }
 
-async function fetchPlayersFromSheet(sheetId: string): Promise<Array<{ username: string; totalWager: number }>> {
+async function fetchPlayersFromSheet(sheetId: string, sheetName?: string): Promise<Array<{ username: string; totalWager: number }>> {
   // Prefer external service to avoid brittle GViz parsing; default to first sheet
-  const url = `${SHEETTOJSON_BASE}/api/sheet?id=${encodeURIComponent(sheetId)}`;
+  let url = `${SHEETTOJSON_BASE}/api/sheet?id=${encodeURIComponent(sheetId)}`;
+  if (sheetName) {
+    url += `&sheet=${encodeURIComponent(sheetName)}`;
+  }
   const resp = await axios.get(url, { timeout: 15000 });
   const payload = resp.data;
 
@@ -132,17 +141,18 @@ async function fetchPlayersFromSheet(sheetId: string): Promise<Array<{ username:
   return players;
 }
 
-async function fetchAggregatedPlayers(source: SourceKey): Promise<Array<{ username: string; totalWager: number }>> {
+async function fetchAggregatedPlayers(source: SourceKey, period: "current" | "previous" = "current"): Promise<Array<{ username: string; totalWager: number }>> {
+  const sheetName = period === "current" ? "Top Wager Current Month" : "Top Wager Past Month";
   if (source === "com") {
-    return await fetchPlayersFromSheet(SHEET_COM_ID).catch(() => []);
+    return await fetchPlayersFromSheet(SHEET_COM_ID, sheetName).catch(() => []);
   }
   if (source === "us") {
-    return await fetchPlayersFromSheet(SHEET_US_ID).catch(() => []);
+    return await fetchPlayersFromSheet(SHEET_US_ID, sheetName).catch(() => []);
   }
   // all
   const [comPlayers, usPlayers] = await Promise.all([
-    fetchPlayersFromSheet(SHEET_COM_ID).catch(() => []),
-    fetchPlayersFromSheet(SHEET_US_ID).catch(() => []),
+    fetchPlayersFromSheet(SHEET_COM_ID, sheetName).catch(() => []),
+    fetchPlayersFromSheet(SHEET_US_ID, sheetName).catch(() => []),
   ]);
 
   const totals = new Map<string, number>();
@@ -158,25 +168,41 @@ async function fetchAggregatedPlayers(source: SourceKey): Promise<Array<{ userna
 }
 
 async function refreshSource(source: SourceKey): Promise<void> {
-  const list = await fetchAggregatedPlayers(source);
+  const [current, previous] = await Promise.all([
+    fetchAggregatedPlayers(source, "current"),
+    fetchAggregatedPlayers(source, "previous")
+  ]);
   hourlyCache[source] = {
-    rawPlayers: list,
+    rawPlayers: current,
+    prevPlayers: previous,
     lastUpdated: Date.now(),
   };
 }
 
 async function refreshAllSources(): Promise<void> {
   await Promise.all([refreshSource("com"), refreshSource("us")]);
-  // Aggregate after com/us are ready
-  const totals = new Map<string, number>();
+
+  // Aggregate CURRENT
+  const totalsCurrent = new Map<string, number>();
   for (const src of ["com", "us"] as const) {
     for (const p of hourlyCache[src].rawPlayers) {
-      const prev = totals.get(p.username) || 0;
-      totals.set(p.username, prev + p.totalWager);
+      const prev = totalsCurrent.get(p.username) || 0;
+      totalsCurrent.set(p.username, prev + p.totalWager);
     }
   }
+
+  // Aggregate PREVIOUS
+  const totalsPrev = new Map<string, number>();
+  for (const src of ["com", "us"] as const) {
+    for (const p of hourlyCache[src].prevPlayers) {
+      const prev = totalsPrev.get(p.username) || 0;
+      totalsPrev.set(p.username, prev + p.totalWager);
+    }
+  }
+
   hourlyCache.all = {
-    rawPlayers: Array.from(totals.entries()).map(([username, totalWager]) => ({ username, totalWager })),
+    rawPlayers: Array.from(totalsCurrent.entries()).map(([username, totalWager]) => ({ username, totalWager })),
+    prevPlayers: Array.from(totalsPrev.entries()).map(([username, totalWager]) => ({ username, totalWager })),
     lastUpdated: Date.now(),
   };
   saveSnapshotToDisk();
@@ -197,16 +223,27 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const sourceParam = (req.query.source as string | undefined)?.toLowerCase();
       const source: SourceKey = sourceParam === "us" ? "us" : sourceParam === "com" ? "com" : "all";
 
+      const periodParam = (req.query.period as string | undefined)?.toLowerCase();
+      const period = periodParam === "previous" ? "previous" : "current";
+
+      const limitParam = (req.query.limit as string | undefined)?.toLowerCase();
+      const isAll = limitParam === "all";
+
       const competition = await storage.getCurrentCompetition();
       if (!competition) {
         return res.status(404).json({ message: "No active competition found" });
       }
 
       // Use hourly snapshot; if empty, perform an on-demand refresh for resiliency
-      let aggregated = hourlyCache[source]?.rawPlayers || [];
+      let aggregated = (period === "current" ? hourlyCache[source]?.rawPlayers : hourlyCache[source]?.prevPlayers) || [];
       if (!aggregated || aggregated.length === 0) {
-        aggregated = await fetchAggregatedPlayers(source);
-        hourlyCache[source] = { rawPlayers: aggregated, lastUpdated: Date.now() };
+        aggregated = await fetchAggregatedPlayers(source, period);
+        if (period === "current") {
+          hourlyCache[source].rawPlayers = aggregated;
+        } else {
+          hourlyCache[source].prevPlayers = aggregated;
+        }
+        hourlyCache[source].lastUpdated = Date.now();
         saveSnapshotToDisk();
       }
       const allPlayers = aggregated
@@ -214,9 +251,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
         .filter((p) => !!p.username)
         .sort((a, b) => b.totalWager - a.totalWager);
 
-      // Get top 10 for display with correct rankings and prizes
-      const players = allPlayers
-        .slice(0, 10)
+      // Get rankings and prizes
+      const slicedPlayers = isAll ? allPlayers : allPlayers.slice(0, 10);
+      const players = slicedPlayers
         .map((player: any, index: number) => {
           const maskedUsername = maskUsername(player.username);
           return {
@@ -227,20 +264,22 @@ export async function registerRoutes(app: Express): Promise<Server> {
           };
         });
 
-      // Update local storage snapshot (for diagnostics/fallbacks)
-      await storage.updateLeaderboardEntries(
-        players.map((p: any) => ({
-          username: p.username,
-          totalWager: p.totalWager.toString(),
-          rank: p.rank
-        }))
-      );
+      // Update local storage snapshot (for diagnostics/fallbacks, only for current top 10)
+      if (period === "current" && !isAll) {
+        await storage.updateLeaderboardEntries(
+          players.map((p: any) => ({
+            username: p.username,
+            totalWager: p.totalWager.toString(),
+            rank: p.rank
+          }))
+        );
+      }
 
       const leaderboardData: LeaderboardData = {
         players,
         totalPrizePool: parseFloat(competition.totalPrizePool),
         totalPlayers: allPlayers.length,
-        lastUpdated: new Date().toISOString()
+        lastUpdated: new Date(hourlyCache[source].lastUpdated).toISOString()
       };
 
       res.json(leaderboardData);


### PR DESCRIPTION
This PR adds the ability for users to view the previous month's leaderboard and the full list of all players.

Key changes:
- Backend: Updated `server/routes.ts` to fetch and cache data from both "Top Wager Current Month" and "Top Wager Past Month" sheets. Added `period` and `limit` query parameters to the `/api/leaderboard` endpoint.
- Frontend: Updated `client/src/pages/leaderboard.tsx` with a tab switcher to toggle between "Current" and "Previous" rankings. Added a "Show Full Leaderboard" button that expands the list beyond the top 10.
- Verification: Changes were verified using Playwright scripts and manual testing of the API endpoints. Type safety was confirmed with `npm run check`.

---
*PR created automatically by Jules for task [8494501109141903815](https://jules.google.com/task/8494501109141903815) started by @ProCoderShekhar*